### PR TITLE
CB-14659. Remove saltboot fingerprint computation via salt-call 'local'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY=salt-bootstrap
 
-VERSION=0.13.4
+VERSION=0.13.5
 BUILD_TIME=$(shell date +%FT%T)
 LDFLAGS=-ldflags "-X github.com/hortonworks/salt-bootstrap/saltboot.Version=${VERSION} -X github.com/hortonworks/salt-bootstrap/saltboot.BuildTime=${BUILD_TIME}"
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")

--- a/saltboot/fingerprint.go
+++ b/saltboot/fingerprint.go
@@ -115,46 +115,6 @@ func distributeFingerprintImpl(distributeRequest func([]string, string, string, 
 	return result
 }
 
-func getMinionFingerprintFromSaltCall() (model.Response, error) {
-	log.Println("[getMinionFingerprintFromSaltCall] get minion fingerprint using salt-call")
-
-	saltLocation := SaltLocation
-	out, err := ExecCmd("find", saltLocation, "-name", "salt-call")
-	if err != nil {
-		log.Printf("[getMinionFingerprintFromSaltCall] cannot execute find command, err: %s", err.Error())
-		return model.Response{}, err
-	}
-
-	var saltCallLocation string
-	for _, findResult := range strings.Split(out, "\n") {
-		if strings.Contains(findResult, "salt-call") {
-			saltCallLocation = findResult
-			break
-		}
-	}
-	if len(saltCallLocation) == 0 {
-		log.Printf("[getMinionFingerprintFromSaltCall] cannot find salt-call executable at %s", saltLocation)
-		return model.Response{}, errors.New("cannot find salt-call executable")
-	}
-	log.Printf("[getMinionFingerprintFromSaltCall] found salt-call at %s", saltCallLocation)
-
-	out, err = ExecCmd(saltCallLocation, "-local", "key.finger")
-	if err != nil {
-		log.Printf("[getMinionFingerprintFromSaltCall] cannot execute salt-call command, err: %s", err.Error())
-		return model.Response{}, err
-	}
-	fingerLines := strings.Split(out, "\n")
-	if len(fingerLines) != 2 {
-		log.Printf("[getMinionFingerprintFromSaltCall] unknown result returned from salt-call: %s", out)
-		return model.Response{}, errors.New("unknown result returned from salt-call")
-	}
-
-	fingerprint := strings.Trim(fingerLines[1], " ")
-	log.Printf("[getMinionFingerprintFromSaltCall] fingerprint: %s", fingerprint)
-
-	return model.Response{Status: fingerprint}, nil
-}
-
 func getMinionFingerprintFromPrivateKey() model.Response {
 	keyLocation := MinionKey
 	log.Println("[getMinionFingerprintFromPrivateKey] generate the fingerprint from the minion's private key: " + keyLocation)

--- a/saltboot/salt.go
+++ b/saltboot/salt.go
@@ -254,12 +254,7 @@ func SaltMinionStopRequestHandler(w http.ResponseWriter, req *http.Request) {
 
 func SaltMinionKeyHandler(w http.ResponseWriter, req *http.Request) {
 	log.Println("[SaltMinionKeyHandler] fetch the salt-minion's fingerprint")
-
-	fingerprint, err := getMinionFingerprintFromSaltCall()
-	if err != nil {
-		log.Println("[SaltMinionKeyHandler] fall back to calculate the fingerprint from the private key")
-		fingerprint = getMinionFingerprintFromPrivateKey()
-	}
+	fingerprint := getMinionFingerprintFromPrivateKey()
 	fingerprint.WriteHttp(w)
 }
 


### PR DESCRIPTION
The 'find /opt -name salt-call' can take 15-20s to execute on slow nodes. The salt-call invocation uses '-local' instead of '--local' and is always broken. Even if --local is used - this takes several seconds, and the key-based-mechanism is what has been exercised for the longest time. Hence removing the salt-call invocation completely.